### PR TITLE
Remove replace directive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -76,36 +76,3 @@ require (
 	k8s.io/utils v0.0.0-20240423183400-0849a56e8f22 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 )
-
-replace (
-	//
-	// k8s.io/kubernetes this is evil....but nessecary for audit2rbac
-	//
-	k8s.io/api => k8s.io/api v0.20.15
-	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.20.15
-	k8s.io/apimachinery => k8s.io/apimachinery v0.20.15
-	k8s.io/apiserver => k8s.io/apiserver v0.20.15
-	k8s.io/cli-runtime => k8s.io/cli-runtime v0.20.15
-	k8s.io/client-go => k8s.io/client-go v0.20.15
-	k8s.io/cloud-provider => k8s.io/cloud-provider v0.20.15
-	k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.20.15
-	k8s.io/code-generator => k8s.io/code-generator v0.20.15
-	k8s.io/component-base => k8s.io/component-base v0.20.15
-	k8s.io/component-helpers => k8s.io/component-helpers v0.20.15
-	k8s.io/controller-manager => k8s.io/controller-manager v0.20.15
-	k8s.io/cri-api => k8s.io/cri-api v0.20.15
-	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.20.15
-	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.20.15
-	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.20.15
-	k8s.io/kube-proxy => k8s.io/kube-proxy v0.20.15
-	k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.20.15
-	k8s.io/kubectl => k8s.io/kubectl v0.20.15
-	k8s.io/kubelet => k8s.io/kubelet v0.20.15
-	k8s.io/legacy-cloud-providers => k8s.io/legacy-cloud-providers v0.20.15
-	k8s.io/metrics => k8s.io/metrics v0.20.15
-	k8s.io/mount-utils => k8s.io/mount-utils v0.20.15
-	k8s.io/node-api => k8s.io/node-api v0.20.15
-	k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.20.15
-	k8s.io/sample-cli-plugin => k8s.io/sample-cli-plugin v0.20.15
-	k8s.io/sample-controller => k8s.io/sample-controller v0.20.15
-)


### PR DESCRIPTION
Remove the replace directives in an attempt to use `go install` against the master branch given the original repo uses the replace directive in go.mod which is not supported by `go install`.